### PR TITLE
Re-write of the ShardDB

### DIFF
--- a/arch/db_spec.md
+++ b/arch/db_spec.md
@@ -1,0 +1,16 @@
+FileDB Spec:
+
+Files are mapped by \[FileID\]\(File\)
+| FileID | File |
+|--------|------|
+|        |      |
+|        |      |
+
+ShardDB Spec:
+
+Shards are mapped by \[ShardID\]\(ShardData\)
+Type should only be used by File type
+| ShardID | ShardData |
+|---------|-----------|
+|         |           |
+|         |           |

--- a/filedb/filedb.go
+++ b/filedb/filedb.go
@@ -17,8 +17,8 @@ import (
 // for all the files on the network.
 type FileDB struct {
 	Header types.DatabaseHeader `json:"header"` // Database header info
-	Name   string               `json:"name"`   // The name of the file db.
-	DB     *bolt.DB             // BoltDB instance
+	Name   string               `json:"name"`   // The name of the file db
+	DB     *bolt.DB             // BoltDB instance (file map)
 
 	Open bool // Status of the DB
 }

--- a/filedb/filedb.go
+++ b/filedb/filedb.go
@@ -51,16 +51,11 @@ func Open(dbName string) (*FileDB, error) {
 	// Prepare to serizlize the FileDB struct
 	filedbPath := path.Join(models.FileDBPath, dbName, "db.json")
 	if _, err := os.Stat(filedbPath); err != nil { // If DB name does not exist
-		// Generate header info
-		header, err := types.NewDatabaseHeader(dbName)
-		if err != nil {
-			return nil, err
-		}
-
 		// Create the fileDB struct
 		fileDB = &FileDB{
-			Header: header, // Set the header
-			Name:   dbName, // Set the name
+			Header: types.NewDatabaseHeader(dbName), // Generate and set the header
+
+			Name: dbName, // Set the name
 		}
 
 		fileDB.serialize(filedbPath) // Write the FileDB struct to disk

--- a/filedb/filedbmodel.go
+++ b/filedb/filedbmodel.go
@@ -1,0 +1,1 @@
+package filedb

--- a/types/databaseheader.go
+++ b/types/databaseheader.go
@@ -15,7 +15,7 @@ type DatabaseHeader struct {
 }
 
 // NewDatabaseHeader creates a new database header.
-func NewDatabaseHeader(label string) (DatabaseHeader, error) {
+func NewDatabaseHeader(label string) DatabaseHeader {
 	// Create the header
 	newDatabaseHeader := DatabaseHeader{
 		Label:   label,
@@ -24,7 +24,7 @@ func NewDatabaseHeader(label string) (DatabaseHeader, error) {
 
 	// Compute the header hash and return
 	newDatabaseHeader.Hash = crypto.Sha3(newDatabaseHeader.Bytes())
-	return newDatabaseHeader, nil
+	return newDatabaseHeader
 }
 
 /* ----- BEGIN HELPER FUNCTIONS ----- */

--- a/types/databaseheader.go
+++ b/types/databaseheader.go
@@ -2,14 +2,10 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/xoreo/meros/crypto"
 )
-
-// ErrNilDBLabel is returned when a nil label is given.
-var ErrNilDBLabel = errors.New("label for creating a shard database header must not be nil")
 
 // DatabaseHeader is the identifier for a database.
 type DatabaseHeader struct {
@@ -20,11 +16,6 @@ type DatabaseHeader struct {
 
 // NewDatabaseHeader creates a new database header.
 func NewDatabaseHeader(label string) (DatabaseHeader, error) {
-	// Check that the label is not nil
-	if label == "" {
-		return DatabaseHeader{}, ErrNilDBLabel
-	}
-
 	// Create the header
 	newDatabaseHeader := DatabaseHeader{
 		Label:   label,

--- a/types/databaseheader_test.go
+++ b/types/databaseheader_test.go
@@ -4,11 +4,6 @@ import "testing"
 
 func TestNewDatabaseHeader(t *testing.T) {
 	label := "test label"
-	header, err := NewDatabaseHeader(label)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	header := NewDatabaseHeader(label)
 	t.Log(header.String())
-
 }

--- a/types/file.go
+++ b/types/file.go
@@ -26,7 +26,7 @@ type File struct {
 	Filename   string      `json:"filename"`   // The file's filename
 	ShardCount int         `json:"shardCount"` // The number of shards hosting the file
 	Size       uint32      `json:"size"`       // The total size of the file
-	ShardDB    *ShardDB    `json:"shardDB"`    // The pointer to the ShardDB, the place where the locations of the shards are stored
+	ShardDB    *shardDB    `json:"shardDB"`    // The pointer to the ShardDB, the place where the locations of the shards are stored
 	Hash       crypto.Hash `json:"hash"`       // The hash of the file
 }
 

--- a/types/file.go
+++ b/types/file.go
@@ -25,8 +25,8 @@ var (
 type File struct {
 	Filename   string      `json:"filename"`   // The file's filename
 	ShardCount int         `json:"shardCount"` // The number of shards hosting the file
-	Size       uint32      `json:"size"`       // The total size of the file
-	ShardDB    *shardDB    `json:"shardDB"`    // The pointer to the ShardDB, the place where the locations of the shards are stored
+	Size       uint32      `json:"size"`       // Total size of the file
+	ShardDB    *shardDB    `json:"shard_db"`   // Pointer to this file's shardDb
 	Hash       crypto.Hash `json:"hash"`       // The hash of the file
 }
 
@@ -49,7 +49,6 @@ func NewFile(filename string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	size := uint32(fileStat.Size())
 	if size == 0 {
 		return nil, ErrNilFileSize
@@ -64,14 +63,7 @@ func NewFile(filename string) (*File, error) {
 
 	// Compress the data
 	bytes = core.CompressBytes(bytes)
-	// Encrypt the data (implement later)
-
-	// Create the shardDB
-	label := filename + "_" + crypto.Sha3(bytes).String()[:8]
-	shardDB, err := NewShardDB(label, bytes)
-	if err != nil {
-		return nil, err
-	}
+	// Encrypt the data as well (implement later)
 
 	shardCount := models.ShardCount
 
@@ -80,7 +72,7 @@ func NewFile(filename string) (*File, error) {
 		Filename:   filename,   // The filename
 		ShardCount: shardCount, // The total amount of shards hostinng the file
 		Size:       size,       // The total size of the file
-		ShardDB:    shardDB,    // The pointer to the (soon to be networked) database of shards
+		ShardDB:    nil,        // nil for now
 	}
 
 	// Compute the hash of the file

--- a/types/shard.go
+++ b/types/shard.go
@@ -44,8 +44,38 @@ func NewShard(bytes []byte) (*Shard, error) {
 	return newShard, nil
 }
 
-// CalculateShardSizes determines the recommended size of each shard.
-func CalculateShardSizes(raw []byte, n int) ([]uint32, error) {
+// GenerateShards generates a slice of shards given a string of bytes
+// This function is a wrapper function. It does not do anything unique.
+func GenerateShards(bytes []byte, n int) ([]*Shard, error) {
+	var shards []*Shard // Init the shard slice
+
+	shardSizes, err := calculateShardSizes(bytes, n) // Calculate the shard sizes
+	if err != nil {
+		return nil, err
+	}
+
+	splitBytes, err := core.SplitBytes(bytes, shardSizes) // Split the bytes into the correct sizes
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate the slices
+	for i := 0; i < len(shardSizes); i++ {
+		// Create a new shard
+		newShard, err := NewShard(
+			splitBytes[i],
+		)
+		if err != nil { // Check error
+			return nil, err
+		}
+		shards = append(shards, newShard) // Append the new shard to the shard slice
+	}
+
+	return shards, nil
+}
+
+// calculateShardSizes determines the recommended size of each shard.
+func calculateShardSizes(raw []byte, n int) ([]uint32, error) {
 	rawSize := len(raw)
 
 	// Check that the input is not null
@@ -71,36 +101,6 @@ func CalculateShardSizes(raw []byte, n int) ([]uint32, error) {
 	sizes[n-1] += modulo // Add the left over bytes to the last element
 
 	return sizes, nil
-}
-
-// GenerateShards generates a slice of shards given a string of bytes
-// This function is a wrapper function. It does not do anything unique.
-func GenerateShards(bytes []byte, n int) ([]*Shard, error) {
-	var shards []*Shard // Init the shard slice
-
-	shardSizes, err := CalculateShardSizes(bytes, n) // Calculate the shard sizes
-	if err != nil {
-		return nil, err
-	}
-
-	splitBytes, err := core.SplitBytes(bytes, shardSizes) // Split the bytes into the correct sizes
-	if err != nil {
-		return nil, err
-	}
-
-	// Generate the slices
-	for i := 0; i < len(shardSizes); i++ {
-		// Create a new shard
-		newShard, err := NewShard(
-			splitBytes[i],
-		)
-		if err != nil { // Check error
-			return nil, err
-		}
-		shards = append(shards, newShard) // Append the new shard to the shard slice
-	}
-
-	return shards, nil
 }
 
 /* ----- BEGIN HELPER FUNCTIONS ----- */

--- a/types/sharddb.go
+++ b/types/sharddb.go
@@ -3,7 +3,7 @@ package types
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
+	"github.com/xoreo/meros/types"
 )
 
 // errNilDBLabel is returned when a nil label is given.
@@ -11,28 +11,24 @@ var errNilDBLabel = errors.New("label for creating a shard database header must 
 
 // shardDB is the database that holds the locations of each shard of a (larger) file.
 type shardDB struct {
-	DB *bolt.DB // BoltDB instance (shard map)
+	header DatabaseHeader        // Database header
+	shards map[shardID]shardData // Shard data map
 
-	Open bool // DB status
+	hash Crypto.Hash // Hash of the entire database
 }
 
-// newShardDB constructs a new database of shards.
-func newShardDB(shards []Shard) (*shardDB, error) {
+// generateShardDB constructs a new database of shards.
+func generateShardDB(shards []Shard) (*shardDB, error) {
+	// Construct the map
+	for shard, i := range shards {
+
+	}
 
 	// Construct the database
-	newShardDB := &shardDB{db, true}
+	sharddb := &shardDB{
+		types.NewDatabaseHeader(""), // Generate and set the header
 
-	return newShardDB, nil
-}
+	}
 
-// populateShardAddresses populates the addresses within the Shards map with peer addresses on the network.
-func (shardDB *shardDB) populateShardAddresses() error {
-
-	return nil
-}
-
-// distributeShards distributes the shards across the network.
-func (shardDB *shardDB) distributeShards() error {
-
-	return nil
+	return sharddb, nil
 }

--- a/types/sharddb.go
+++ b/types/sharddb.go
@@ -3,7 +3,6 @@ package types
 import (
 	"errors"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/xoreo/meros/crypto"
 )
 
@@ -12,26 +11,27 @@ var errNilDBLabel = errors.New("label for creating a shard database header must 
 
 // shardDB is the database that holds the locations of each shard of a (larger) file.
 type shardDB struct {
-	header DatabaseHeader        // Database header
-	shards map[shardID]shardData // Shard data map
+	header   DatabaseHeader        // Database header
+	shardMap map[shardID]shardData // Shard data map
 
 	hash crypto.Hash // Hash of the entire database
 }
 
 // generateShardDB constructs a new shard database.
-func generateShardDB(shards []Shard, nodeIDs []NodeID) (*shardDB, error) {
+func generateShardDB(shards []Shard, nodeIDs []NodeID) (shardDB, error) {
 	// Construct the map
-	shardMap := make(map[peer.ID]*Shard)
+	shardMap := make(map[shardID]shardData)
 
 	// Generate and add shard data to the map
-	for shard, i := range shards {
-		id, data := generateShardEntry(shard)
+	for i, shard := range shards {
+		id, data := generateShardEntry(shard, i, nodeIDs[i]) // Generate the pair
+		shardMap[id] = data                                  // Put the data in the map
 	}
 
 	// Construct the database
-	sharddb := &shardDB{
-		NewDatabaseHeader(""), // Generate and set the header
-		shardMap,              // Set the shardMap
+	sharddb := shardDB{
+		header:   NewDatabaseHeader(""), // Generate and set the header
+		shardMap: shardMap,              // Set the shardMap
 	}
 
 	return sharddb, nil

--- a/types/sharddb.go
+++ b/types/sharddb.go
@@ -3,7 +3,8 @@ package types
 import (
 	"errors"
 
-	"github.com/xoreo/meros/types"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/xoreo/meros/crypto"
 )
 
 // errNilDBLabel is returned when a nil label is given.
@@ -14,20 +15,23 @@ type shardDB struct {
 	header DatabaseHeader        // Database header
 	shards map[shardID]shardData // Shard data map
 
-	hash Crypto.Hash // Hash of the entire database
+	hash crypto.Hash // Hash of the entire database
 }
 
-// generateShardDB constructs a new database of shards.
-func generateShardDB(shards []Shard) (*shardDB, error) {
+// generateShardDB constructs a new shard database.
+func generateShardDB(shards []Shard, nodeIDs []NodeID) (*shardDB, error) {
 	// Construct the map
-	for shard, i := range shards {
+	shardMap := make(map[peer.ID]*Shard)
 
+	// Generate and add shard data to the map
+	for shard, i := range shards {
+		id, data := generateShardEntry(shard)
 	}
 
 	// Construct the database
 	sharddb := &shardDB{
-		types.NewDatabaseHeader(""), // Generate and set the header
-
+		NewDatabaseHeader(""), // Generate and set the header
+		shardMap,              // Set the shardMap
 	}
 
 	return sharddb, nil

--- a/types/sharddb.go
+++ b/types/sharddb.go
@@ -1,57 +1,38 @@
 package types
 
 import (
-	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/xoreo/meros/models"
+	"errors"
+
+	"github.com/boltdb/bolt"
 )
 
-// ShardDB is the database that holds the locations of each shard of a (larger) file.
-type ShardDB struct {
-	Header DatabaseHeader     `json:"header"` // The database header contains some DB metadata
-	Shards map[peer.ID]*Shard `json:"shards"` // The shards themselves
+// errNilDBLabel is returned when a nil label is given.
+var errNilDBLabel = errors.New("label for creating a shard database header must not be nil")
+
+// shardDB is the database that holds the locations of each shard of a (larger) file.
+type shardDB struct {
+	DB *bolt.DB // BoltDB instance (shard map)
+
+	Open bool // DB status
 }
 
-// NewShardDB constructs a new database of shards.
-func NewShardDB(label string, bytes []byte) (*ShardDB, error) {
-	// Check for valid label
-	if label == "" {
-		return nil, ErrNilDBLabel
-	}
+// newShardDB constructs a new database of shards.
+func newShardDB(shards []Shard) (*shardDB, error) {
 
-	// Check that file is not nil
-	if len(bytes) == 0 {
-		return nil, ErrNilFileSize
-	}
-
-	newHeader, err := NewDatabaseHeader(label) // Construct the database header
-	if err != nil {
-		return nil, err
-	}
-
-	// Generate the actual shards
-	_, err = GenerateShards(bytes, models.ShardCount)
-	if err != nil {
-		return nil, err
-	}
-
-	shardMap := make(map[peer.ID]*Shard)
-
-	// Find online peers, put node addresses as keys in map and shards as values
-
-	// Construct the shard itself
-	newShardDB := &ShardDB{
-		Header: newHeader,
-		Shards: shardMap,
-	}
+	// Construct the database
+	newShardDB := &shardDB{db, true}
 
 	return newShardDB, nil
 }
 
-/*
-THESE METHODS WILL GO IN THE NET PACKAGE:
-// PopulateShardAddresses populates the addresses within the Shards map with peer addresses on the network.
-func (shardDB *ShardDB) PopulateShardAddresses() error
+// populateShardAddresses populates the addresses within the Shards map with peer addresses on the network.
+func (shardDB *shardDB) populateShardAddresses() error {
 
-// DistributeShards distributes the shards across the network.
-func (shardDB *ShardDB) DistributeShards() error
-*/
+	return nil
+}
+
+// distributeShards distributes the shards across the network.
+func (shardDB *shardDB) distributeShards() error {
+
+	return nil
+}

--- a/types/sharddbmodel.go
+++ b/types/sharddbmodel.go
@@ -14,10 +14,6 @@ type shardData struct {
 	Size   uint32 `json:"size"`    // The size in bytes of the shard
 }
 
-func calculateShardID(shard Shard) shardID {
-
-}
-
 // generateShardEntry generates a shardID-shardData pair.
 func generateShardEntry(shard Shard, index int, nodeID NodeID) (shardID, shardData) {
 	shardData := shardData{
@@ -25,7 +21,6 @@ func generateShardEntry(shard Shard, index int, nodeID NodeID) (shardID, shardDa
 		NodeID: nodeID,     // Set the NodeID
 		Size:   shard.Size, // Get and set the size
 	}
-	shardid := calculateShardID(shard) // Calculate the shardID of the shard
 
-	return shardid, shardData // Return the pair
+	return shardID(shard.Hash), shardData // Return the pair
 }

--- a/types/sharddbmodel.go
+++ b/types/sharddbmodel.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"crypto"
+)
+
+// shardID is the key model in the shard map (shard db).
+type shardID crypto.Hash
+
+// shardData is the value model in the shard map (shard db).
+type shardData struct {
+	NodeID NodeID `json:"node_id"` // The ID of the node holding the shard
+	Index  int    `json:"index"`   // The position of the shard out of all the shards for this file
+	Size   uint32 `json:"size"`    // The size in bytes of the shard
+}
+
+func generateShardEntry(shard Shard) (shardData, shardID) {
+
+}

--- a/types/sharddbmodel.go
+++ b/types/sharddbmodel.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"crypto"
+	"github.com/xoreo/meros/crypto"
 )
 
 // shardID is the key model in the shard map (shard db).
@@ -9,11 +9,23 @@ type shardID crypto.Hash
 
 // shardData is the value model in the shard map (shard db).
 type shardData struct {
-	NodeID NodeID `json:"node_id"` // The ID of the node holding the shard
 	Index  int    `json:"index"`   // The position of the shard out of all the shards for this file
+	NodeID NodeID `json:"node_id"` // The ID of the node holding the shard
 	Size   uint32 `json:"size"`    // The size in bytes of the shard
 }
 
-func generateShardEntry(shard Shard) (shardData, shardID) {
+func calculateShardID(shard Shard) shardID {
 
+}
+
+// generateShardEntry generates a shardID-shardData pair.
+func generateShardEntry(shard Shard, index int, nodeID NodeID) (shardID, shardData) {
+	shardData := shardData{
+		Index:  index,      // Set the index
+		NodeID: nodeID,     // Set the NodeID
+		Size:   shard.Size, // Get and set the size
+	}
+	shardid := calculateShardID(shard) // Calculate the shardID of the shard
+
+	return shardid, shardData // Return the pair
 }

--- a/types/sharddbmodel_test.go
+++ b/types/sharddbmodel_test.go
@@ -1,0 +1,7 @@
+package types
+
+import "testing"
+
+func TestGenerateShardEntry(t *testing.T) {
+
+}


### PR DESCRIPTION
1. Complete re-write of the shard database, a component of the `type File struct`
2. Replaced the BoltDB instance in the ShardDB with a primitive `map`
3. Added database models for the `shardDB` map.
